### PR TITLE
Show book units on click

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,6 +35,11 @@ class FlashcardApp {
             this.showBookSelection();
         });
 
+        // Add breadcrumb navigation
+        document.getElementById('backToBooks').addEventListener('click', () => {
+            this.showBookSelection();
+        });
+
         document.getElementById('backToUnits').addEventListener('click', () => {
             this.showUnitSelection();
         });
@@ -111,6 +116,14 @@ class FlashcardApp {
 
     showUnitSelection() {
         document.getElementById('unitSelection').style.display = 'block';
+        // Update the header to show which book is selected
+        const bookTitle = vocabularyData.books[this.currentBook].title;
+        document.querySelector('#unitSelection h2').textContent = `Units in ${bookTitle}`;
+        
+        // Update back button to show which book we're returning to
+        const backBtn = document.getElementById('backToBooks');
+        backBtn.innerHTML = `← Back to ${bookTitle}`;
+        
         this.renderUnits();
     }
 
@@ -132,6 +145,9 @@ class FlashcardApp {
             unitCard.innerHTML = `
                 <h3>Unit ${unitNumber}</h3>
                 <p>${unit.title}</p>
+                <div class="unit-info">
+                    <span class="word-count">${unit.words.length} words</span>
+                </div>
                 <div class="unit-status">
                     ${unitData.studied ? '✓ Studied' : 'Not studied'} | 
                     ${unitData.practiced ? '✓ Practiced' : 'Not practiced'}

--- a/styles.css
+++ b/styles.css
@@ -379,6 +379,39 @@ body::before {
     font-size: 0.9rem;
 }
 
+.unit-info {
+    margin: 8px 0;
+}
+
+.word-count {
+    display: inline-block;
+    background: linear-gradient(135deg, #58cc02, #46b000);
+    color: white;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.unit-status {
+    font-size: 0.8rem;
+    color: #6c757d;
+    font-weight: 500;
+    margin-top: 10px;
+    padding: 8px 12px;
+    background: rgba(108, 117, 125, 0.1);
+    border-radius: 8px;
+    border: 1px solid rgba(108, 117, 125, 0.2);
+}
+
+.unit-card.completed .unit-status {
+    background: rgba(88, 204, 2, 0.1);
+    color: #58cc02;
+    border-color: rgba(88, 204, 2, 0.3);
+}
+
 /* Study Mode */
 .study-mode {
     background: rgba(255, 255, 255, 0.98);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enhance unit display and navigation to improve user experience when selecting a book.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
While the core functionality to show units on book click was already present, this PR adds visual enhancements like dynamic headers, word counts on unit cards, and improved back navigation for better context and clarity. It also addresses a missing CSS class for unit status.

---
<a href="https://cursor.com/background-agent?bcId=bc-b307cce6-25c9-4dc9-ac4c-961b57f22e89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b307cce6-25c9-4dc9-ac4c-961b57f22e89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>